### PR TITLE
Photochem v0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "photochem" %}
-{% set version = "0.4.1" %}
+{% set version = "0.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/Nicholaswogan/photochem/releases/download/v{{ version }}/photochem-{{ version }}_withdata.tar.gz
-  sha256: fe5935c7740dddcff3b9c3f866ad122a8529973635acf0f2a16a1bb786cc3413
+  sha256: 653b89f1bd9369aaa79efc5c20da8b8db98ced179b5f0d2221a8323db81ba9f1
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Nicholaswogan/photochem/releases/download/v{{ version }}/photochem-{{ version }}_withdata.tar.gz
-  sha256: 653b89f1bd9369aaa79efc5c20da8b8db98ced179b5f0d2221a8323db81ba9f1
+  sha256: 947b3c0d9438a1c1177abbaa7f300eddd205a9194286e3a2fb76ce118c260e29
 
 build:
   skip: true  # [win]


### PR DESCRIPTION
v0.4.2 is identical to v0.4.1 except, I use h5fortran v4.5.0. I think this difference will allow the osx-arm conda-forge builds to succeed.